### PR TITLE
Round to 3 fraction digits

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,8 +19,9 @@ module.exports = function(){
       // Wait for the page to finish loading
       const pageLoadedIn = performance.mark("pageLoadedIn")
       const loadTime = pageLoadedIn.startTime / 1000
+      const loadTimeRounded = loadTime.toLocaleString('en-US', {minimumFractionDigits: 3, maximumFractionDigits: 3})
 
-      $elem.innerHTML += `Page loaded in ${loadTime}s.</p>`
+      $elem.innerHTML += `Page loaded in ${loadTimeRounded}s.</p>`
     }
   })
 }()


### PR DESCRIPTION
This fixes the sometimes awkwardly-long results as seen on www.silvestar.codes in Chrome 113: “Page loaded in 0.9648999999761582s.”

Chrome gives you 4 fractional digits of value from their high-resolution timestamps, and it might be more in the future, but 3 digits is the most human-friendly representation of page loading time.

This also ensures that there’s always three digits shown, otherwise results like “0.27s” leaves to interpretation whether it’s intentionally rounded to 2 digits or if the third digit is indeed 0.